### PR TITLE
POM changes for central repo deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,41 @@
 
     <description>Reactor project to build hook and sample package.</description>
 
+    <developers>
+        <developer>
+            <name>Conrad Wöltge</name>
+            <email>conrad.woeltge@netcentric.biz</email>
+            <organization>Netcentric</organization>
+            <organizationUrl>http://www.netcentric.biz/</organizationUrl>
+        </developer>
+    </developers>
+
+    <distributionManagement>
+         <snapshotRepository>
+             <id>ossrh</id>
+             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+         </snapshotRepository>
+         <repository>
+             <id>ossrh</id>
+             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+         </repository>
+     </distributionManagement>
+
+    <licenses>
+        <license>
+            <name>Eclipse Public License, Version 1.0</name>
+            <url>https://www.eclipse.org/legal/epl-v10.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:https://github.com/Netcentric/vault-upgrade-hook.git</connection>
+        <developerConnection>scm:git:https://github.com/Netcentric/vault-upgrade-hook.git</developerConnection>
+        <url>https://github.com/Netcentric/vault-upgrade-hook.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <!-- ====================================================================== -->
     <!-- P R O P E R T I E S -->
     <!-- ====================================================================== -->
@@ -30,6 +65,24 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.7</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <modules>
         <module>vault-upgrade-hook</module>
         <module>groovy-sample-package</module>
@@ -37,6 +90,27 @@
     </modules>
 
     <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>autoInstallBundle</id>
             <build>


### PR DESCRIPTION
Prepares for a release of the project to the maven central repo described in issue #6 

Added:
* developer info
* distributionManagement urls
* scm block
* nexus-staging-maven-plugin
* maven-gpg-plugin under release profile