### PR TITLE
Add usage of custom binding in `data` field.

### DIFF
--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/UpgradeAction.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/UpgradeAction.java
@@ -81,10 +81,10 @@ public abstract class UpgradeAction implements Comparable<UpgradeAction> {
 
     protected static String getDataMd5(final Node script) throws RepositoryException {
         final String encoding = JcrUtils.getStringProperty(script, JcrConstants.JCR_CONTENT + "/" + JcrConstants.JCR_ENCODING, "utf-8");
-        return getMd5(getData(script), encoding);
+        return getMd5(getScriptContent(script), encoding);
     }
 
-    protected static String getData(final Node script) throws RepositoryException {
+    protected static String getScriptContent(final Node script) throws RepositoryException {
         final String dataPath = JcrConstants.JCR_CONTENT + "/" + JcrConstants.JCR_DATA;
         if (script.hasProperty(dataPath)) {
             return JcrUtils.getStringProperty(script, dataPath, "");

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/groovy/GroovyScript.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/groovy/GroovyScript.java
@@ -62,10 +62,20 @@ public class GroovyScript extends UpgradeAction {
 
     protected SlingHttpServletRequest getRequestForScript() throws RepositoryException {
         final Map<String, Object> parameters = new HashMap<>();
-        parameters.put("script", getData(script));
+        parameters.put("script", getScriptContent(script));
         parameters.put("scriptPath", script.getPath());
+        parameters.put("data", getData());
         return new FakeRequest(sling.getResourceResolver(script.getSession()), "GET", "/bin/groovyconsole/post.json",
                 parameters);
+    }
+
+    private String getData() throws RepositoryException {
+        String data = script.hasProperty("data") ? script.getProperty("data").getString() : "";
+        if (data.equals("")) {
+            Node parent = script.getParent();
+            data = parent.hasProperty("data") ? parent.getProperty("data").getString() : "";
+        }
+        return data;
     }
 
 }

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/groovy/GroovyScript.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/groovy/GroovyScript.java
@@ -70,12 +70,8 @@ public class GroovyScript extends UpgradeAction {
     }
 
     private String getData() throws RepositoryException {
-        String data = script.hasProperty("data") ? script.getProperty("data").getString() : "";
-        if (data.equals("")) {
-            Node parent = script.getParent();
-            data = parent.hasProperty("data") ? parent.getProperty("data").getString() : "";
-        }
-        return data;
+        Node parent = script.getParent();
+        return parent.hasProperty("data") ? parent.getProperty("data").getString() : "";
     }
 
 }


### PR DESCRIPTION
Use property "data" as data-binding attribute. 
By default files "*.groovy" files does not have attributes that is why provided fall back to "data" property of parent node.