### PR TITLE
Support runmode specific execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ This behaviour can be changed by configuration options
 
 In case of specifying incorrect value for `mode` - current action will not be executed and the package installation is failed.
 
-Furthermore it is optionally possible to limit the execution of all `UpgradeAction`s within a single `UpgradeInfo` to specific runmodes. To do so set the `runmodes` property to an array of applicable runmodes.
+Furthermore it is possible to limit the execution of all `UpgradeAction`s within a single `UpgradeInfo` to specific runmodes. To do so set the `runmodes` property to an array of applicable runmodes. Multiple required runmodes are set concatenating them with a dot:
+
+- if the `runmodes` are set to `[dev,test]` actions are executed on both dev and test runmode (disjunctive)
+- if the `runmodes` are set to `[author.dev1]` actions are executed only on instances with author and dev1 runmode (conjunctive)
 
 `UpgradeAction`s are bound to a specific execution phase. The default Phase is `PREPARE`. This means an arbitrary action is executed before the content is installed. Specific handlers may provide additional way of configuring this or restrict to specific phase (for provided samples see corresponding readme files). This can be overridden by prefixing the script/configuration name with the name of another phase e.g. "prepare_failed-myscript.groovy".
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This behaviour can be changed by configuration options
 
 In case of specifying incorrect value for `mode` - current action will not be executed and the package installation is failed.
 
+Furthermore it is optionally possible to limit the execution of all `UpgradeAction`s within a single `UpgradeInfo` to specific runmodes. To do so set the `runmodes` property to an array of applicable runmodes.
+
 `UpgradeAction`s are bound to a specific execution phase. The default Phase is `PREPARE`. This means an arbitrary action is executed before the content is installed. Specific handlers may provide additional way of configuring this or restrict to specific phase (for provided samples see corresponding readme files). This can be overridden by prefixing the script/configuration name with the name of another phase e.g. "prepare_failed-myscript.groovy".
 
 ### Upgrade Actions

--- a/samples/groovy-package/src/main/upgrader/always-on-author/.content.xml
+++ b/samples/groovy-package/src/main/upgrader/always-on-author/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:vlt="http://www.day.com/jcr/vault/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          jcr:primaryType="sling:Folder"
+          handler="groovyconsole"
+          mode="always"
+          runmodes="[author]"/>

--- a/samples/groovy-package/src/main/upgrader/always-on-author/always.groovy
+++ b/samples/groovy-package/src/main/upgrader/always-on-author/always.groovy
@@ -1,0 +1,2 @@
+def resource = getResource('/content/we-retail/jcr:content');
+resource.adaptTo(ModifiableValueMap).put('alwaysOnAuthor', ++(resource.valueMap['alwaysOnAuthor'] ?: 0))

--- a/vault-upgrade-hook/pom.xml
+++ b/vault-upgrade-hook/pom.xml
@@ -81,6 +81,11 @@
             <version>2.7.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.settings</artifactId>
+            <version>1.3.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
             <version>2.8.0</version>

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/OsgiUtil.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/OsgiUtil.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OsgiUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(OsgiUtil.class);
+    protected static final Logger LOG = LoggerFactory.getLogger(OsgiUtil.class);
 
     public <T> ServiceWrapper<T> getService(Class<T> clazz) {
         Bundle bundle = FrameworkUtil.getBundle(clazz);

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
@@ -35,12 +35,7 @@ public class SlingUtils extends OsgiUtil {
     }
 
     public boolean hasRunModes(Set<String> requiredRunModes) {
-        Set<String> actualRunMode = getRunModes();
-        boolean hasAll = true;
-        for (Iterator<String> it = requiredRunModes.iterator(); it.hasNext() && hasAll; ) {
-            hasAll = actualRunMode.contains(it.next());
-        }
-        return hasAll;
+        return requiredRunModes.isEmpty() || getRunModes().containsAll(requiredRunModes);
     }
 
     private Set<String> getRunModes() {

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
@@ -35,10 +35,10 @@ public class SlingUtils extends OsgiUtil {
     }
 
     public boolean hasRunModes(Set<String> requiredRunModes) {
-        return requiredRunModes.isEmpty() || getRunModes().containsAll(requiredRunModes);
+        return getRunModes().containsAll(requiredRunModes);
     }
 
-    private Set<String> getRunModes() {
+    protected Set<String> getRunModes() {
         try (ServiceWrapper<SlingSettingsService> serviceWrapper = getService(SlingSettingsService.class)) {
             return serviceWrapper.getService().getRunModes();
         } catch (IllegalStateException ex) {

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
@@ -8,6 +8,8 @@
  */
 package biz.netcentric.vlt.upgrade.handler;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
@@ -35,7 +37,18 @@ public class SlingUtils extends OsgiUtil {
     }
 
     public boolean hasRunModes(Set<String> requiredRunModes) {
-        return getRunModes().containsAll(requiredRunModes);
+        Iterator<String> it = requiredRunModes.iterator();
+        boolean hasMatchingSetOfRunModes = requiredRunModes.isEmpty();
+        while (!hasMatchingSetOfRunModes && it.hasNext()) {
+            String next = it.next();
+            if (next == null || next.length() == 0) {
+                // Set allows at most one null object, also empty string doesn't make sense
+                throw new IllegalArgumentException("null or empty string cannot be a required runmode.");
+            }
+            Collection<String> collectionOfRequiredRunModes = Arrays.asList(next.split("\\."));
+            hasMatchingSetOfRunModes = getRunModes().containsAll(collectionOfRequiredRunModes);
+        }
+        return hasMatchingSetOfRunModes;
     }
 
     protected Set<String> getRunModes() {

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/SlingUtils.java
@@ -9,12 +9,15 @@
 package biz.netcentric.vlt.upgrade.handler;
 
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
 
 import javax.jcr.Session;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.settings.SlingSettingsService;
 
 /**
  * Helper class extending {@link OsgiUtil} to get a Sling
@@ -23,7 +26,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 public class SlingUtils extends OsgiUtil {
 
     public ResourceResolver getResourceResolver(Session session) {
-        try (ServiceWrapper<ResourceResolverFactory> serviceWrapper = getService(ResourceResolverFactory.class);) {
+        try (ServiceWrapper<ResourceResolverFactory> serviceWrapper = getService(ResourceResolverFactory.class)) {
             return serviceWrapper.getService()
                     .getResourceResolver(Collections.<String, Object>singletonMap("user.jcr.session", session));
         } catch (LoginException e) {
@@ -31,4 +34,21 @@ public class SlingUtils extends OsgiUtil {
         }
     }
 
+    public boolean hasRunModes(Set<String> requiredRunModes) {
+        Set<String> actualRunMode = getRunModes();
+        boolean hasAll = true;
+        for (Iterator<String> it = requiredRunModes.iterator(); it.hasNext() && hasAll; ) {
+            hasAll = actualRunMode.contains(it.next());
+        }
+        return hasAll;
+    }
+
+    private Set<String> getRunModes() {
+        try (ServiceWrapper<SlingSettingsService> serviceWrapper = getService(SlingSettingsService.class)) {
+            return serviceWrapper.getService().getRunModes();
+        } catch (IllegalStateException ex) {
+            LOG.debug("Failed to get SlingSettingsService. Returning empty set of runmodes.", ex);
+            return Collections.emptySet();
+        }
+    }
 }

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/StringUtils.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/StringUtils.java
@@ -1,0 +1,31 @@
+package biz.netcentric.vlt.upgrade.handler;
+
+import java.nio.CharBuffer;
+
+public class StringUtils {
+
+    public static final String join(char separator, String... parts) {
+        return join(CharBuffer.wrap(new char[] { separator }), parts);
+    }
+
+    public static final String join(CharSequence separator, String... parts) {
+        if (parts == null) {
+            parts = new String[] { null };
+        }
+        int length = 0;
+
+        final int separatorLength = separator.length();
+        for (String part : parts) {
+            length += (part == null ? 4 : part.length()) + separatorLength;
+        }
+
+        final StringBuilder result = new StringBuilder(length);
+        for (int i = 0; i < parts.length; i++) {
+            result.append(parts[i]);
+            if (i + 1 < parts.length) {
+                result.append(separator);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/StringUtils.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/handler/StringUtils.java
@@ -4,11 +4,11 @@ import java.nio.CharBuffer;
 
 public class StringUtils {
 
-    public static final String join(char separator, String... parts) {
+    public static String join(char separator, String... parts) {
         return join(CharBuffer.wrap(new char[] { separator }), parts);
     }
 
-    public static final String join(CharSequence separator, String... parts) {
+    public static String join(CharSequence separator, String... parts) {
         if (parts == null) {
             parts = new String[] { null };
         }

--- a/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/UpgradeInfoTest.java
+++ b/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/UpgradeInfoTest.java
@@ -96,6 +96,44 @@ public class UpgradeInfoTest {
         Assert.assertEquals(InstallationMode.ALWAYS, info.getInstallationMode());
         Assert.assertEquals(Phase.PREPARE, info.getDefaultPhase());
         Assert.assertTrue(info.getHandler() instanceof TestHandler);
+        Assert.assertTrue(info.getRunModes().isEmpty());
+    }
+
+    @Test
+    public void testConstructorWithRunMode() throws Exception {
+        sling.build().resource("/test", //
+                UpgradeInfo.PN_INSTALLATION_MODE, "always", //
+                UpgradeInfo.PN_DEFAULT_PHASE, "prepare", //
+                UpgradeInfo.PN_HANDLER, TEST_HANDLER, //
+                UpgradeInfo.PN_RUNMODES, "publish" //
+        );
+        Node node = session.getNode("/test");
+        UpgradeInfo info = new UpgradeInfo(ctx, status, node);
+        info.loadActions(ctx);
+
+        Assert.assertEquals(InstallationMode.ALWAYS, info.getInstallationMode());
+        Assert.assertEquals(Phase.PREPARE, info.getDefaultPhase());
+        Assert.assertTrue(info.getHandler() instanceof TestHandler);
+        Assert.assertTrue(info.getRunModes().contains("publish"));
+    }
+
+    @Test
+    public void testConstructorWithRunModes() throws Exception {
+        sling.build().resource("/test", //
+                UpgradeInfo.PN_INSTALLATION_MODE, "always", //
+                UpgradeInfo.PN_DEFAULT_PHASE, "prepare", //
+                UpgradeInfo.PN_HANDLER, TEST_HANDLER, //
+                UpgradeInfo.PN_RUNMODES, new String[] { "publish", "author" } //
+        );
+        Node node = session.getNode("/test");
+        UpgradeInfo info = new UpgradeInfo(ctx, status, node);
+        info.loadActions(ctx);
+
+        Assert.assertEquals(InstallationMode.ALWAYS, info.getInstallationMode());
+        Assert.assertEquals(Phase.PREPARE, info.getDefaultPhase());
+        Assert.assertTrue(info.getHandler() instanceof TestHandler);
+        Assert.assertTrue(info.getRunModes().contains("publish"));
+        Assert.assertTrue(info.getRunModes().contains("author"));
     }
 
     public static class TestHandler implements UpgradeHandler {

--- a/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/handler/SlingUtilsTest.java
+++ b/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/handler/SlingUtilsTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -24,8 +25,27 @@ public class SlingUtilsTest {
     @Test
     public void testHasRunModes() {
         Assert.assertTrue(toTest.hasRunModes(Collections.<String>emptySet()));
+
         Assert.assertTrue(toTest.hasRunModes(ImmutableSet.of("runmode1", "runmode2")));
         Assert.assertTrue(toTest.hasRunModes(ImmutableSet.of("runmode1")));
+        Assert.assertTrue(toTest.hasRunModes(ImmutableSet.of("runmode1", "runmode3")));
+        Assert.assertTrue(toTest.hasRunModes(ImmutableSet.of("runmode1.runmode2")));
+
         Assert.assertFalse(toTest.hasRunModes(ImmutableSet.of("runmode3")));
+        Assert.assertFalse(toTest.hasRunModes(ImmutableSet.of("runmode1.runmode3")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasRunModesNull() {
+        Set<String> nullSet = new HashSet<>();
+        nullSet.add(null);
+        toTest.hasRunModes(nullSet);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasRunModesEmpty() {
+        Set<String> nullSet = new HashSet<>();
+        nullSet.add("");
+        toTest.hasRunModes(nullSet);
     }
 }

--- a/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/handler/SlingUtilsTest.java
+++ b/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/handler/SlingUtilsTest.java
@@ -1,0 +1,31 @@
+package biz.netcentric.vlt.upgrade.handler;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+public class SlingUtilsTest {
+
+    private SlingUtils toTest = spy(new SlingUtils());
+
+    @Before
+    public void setup() {
+        doReturn(ImmutableSet.of("runmode1", "runmode2")).when(toTest).getRunModes();
+    }
+
+    @Test
+    public void testHasRunModes() {
+        Assert.assertTrue(toTest.hasRunModes(Collections.<String>emptySet()));
+        Assert.assertTrue(toTest.hasRunModes(ImmutableSet.of("runmode1", "runmode2")));
+        Assert.assertTrue(toTest.hasRunModes(ImmutableSet.of("runmode1")));
+        Assert.assertFalse(toTest.hasRunModes(ImmutableSet.of("runmode3")));
+    }
+}

--- a/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/handler/StringUtilsTest.java
+++ b/vault-upgrade-hook/src/test/java/biz/netcentric/vlt/upgrade/handler/StringUtilsTest.java
@@ -1,0 +1,23 @@
+package biz.netcentric.vlt.upgrade.handler;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testJoinNullStrings() {
+        assertEquals("null,null", StringUtils.join(',', null, null));
+    }
+
+    @Test
+    public void testJoinStringsWithSeparatorChar() {
+        assertEquals("a,b", StringUtils.join(',', "a", "b"));
+    }
+
+    @Test
+    public void testJoinStringsWithSeparatorSeq() {
+        assertEquals("a..b", StringUtils.join("..", "a", "b"));
+    }
+}


### PR DESCRIPTION
This changeset extends the UpdateInfo with a multi value string field for runmodes. If
they are specified the update actions of that particular UpdateInfo will only executed
when running with all of the specified runmodes. If nothing is specified the actions
will be executed on all runmodes.

Resolves #38