### PR TITLE
bugfix/40-multiple-upgradeinfo-instances-are-not-sorted

### DIFF
--- a/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/UpgradeProcessor.java
+++ b/vault-upgrade-hook/src/main/java/biz/netcentric/vlt/upgrade/UpgradeProcessor.java
@@ -172,7 +172,7 @@ public class UpgradeProcessor implements InstallHook {
                 @Override
                 public int compare(UpgradeInfo info1, UpgradeInfo info2) {
                     try {
-                        return info1.getNode().getName().compareTo(info1.getNode().getName());
+                        return info1.getNode().getName().compareTo(info2.getNode().getName());
                     } catch (RepositoryException e) {
                         LOG.warn(ctx, "Could not compare upgrade infos [{}/{}]", info1.getNode(), info2.getNode(), e);
                         return 0;


### PR DESCRIPTION
Fixed typo in UpgradeProcessor.loadInfo method that causes two or more UpgradeInfo instances were not sorted as expected.

Adding a test to prevent to check ordering when multiple UpgradeInfo exists